### PR TITLE
Update sbe_schema_validator.hpp

### DIFF
--- a/sbeppc/src/sbepp/sbeppc/sbe_schema_validator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/sbe_schema_validator.hpp
@@ -615,6 +615,12 @@ private:
     template<typename T>
     static bool can_be_parsed_as(const std::string_view str)
     {
+        if constexpr (std::is_same_v<T, char>) {
+            if (str.size() == 1){
+                return true; // str contains a single letter
+            }
+        }
+        
         return utils::string_to_number<T>(str).has_value();
     }
 


### PR DESCRIPTION
For enum types with encodingType="Char" utils::string_to_number<T>(str).has_value() may return false because std::from_chars may return std::errc::invalid_argument if value e.g. "A" (str contains a single letter)